### PR TITLE
feat(pre-aggregates): auto-hit pre-aggregate extensions for top dashboards

### DIFF
--- a/dbt-bigquery/models/dbt_baskets.yml
+++ b/dbt-bigquery/models/dbt_baskets.yml
@@ -12,6 +12,7 @@ models:
           metrics:
             - sum_of_item_profit
             - count_of_product_name
+            - sum_of_basket_total
           refresh:
             # every 5 minutes
             cron: "*/5 * * * *"
@@ -23,6 +24,7 @@ models:
           metrics:
             - sum_of_item_profit
             - count_of_product_name
+            - sum_of_basket_total
           filters:
             - order_date: inThePast 52 weeks
           time_dimension: order_date

--- a/dbt-bigquery/models/dbt_orders.yml
+++ b/dbt-bigquery/models/dbt_orders.yml
@@ -11,16 +11,21 @@ models:
           metrics:
             - sum_of_basket_total
             - sum_of_profit
+            - average_of_basket_total
+            - avg_profit
           time_dimension: order_date
           granularity: DAY
         - name: orders_partner_geo_daily
           dimensions:
             - partner_name
+            - partner_commission
             - shipping_country
             - browser
           metrics:
             - sum_of_basket_total
             - sum_of_profit
+            - average_of_basket_total
+            - avg_profit
           time_dimension: order_date
           granularity: DAY
       spotlight:

--- a/dbt-bigquery/models/dbt_support_requests.yml
+++ b/dbt-bigquery/models/dbt_support_requests.yml
@@ -4,6 +4,14 @@ models:
       received'
     meta:
       label: Support requests
+      pre_aggregates:
+        - name: support_requests_daily
+          dimensions:
+            - reason
+          metrics:
+            - average_of_feedback_rating
+          time_dimension: request_date
+          granularity: DAY
       joins:
         - join: dbt_orders
           sql_on: ${dbt_orders.order_id} = ${dbt_support_requests.order_id}


### PR DESCRIPTION
## v0 — auto-hit extensions only

Bulk-audited the 20 most-viewed dashboards in Thyme to Shine Market against the existing pre-aggregates + the downloaded chart YAML. This PR adds only the dbt changes that auto-hit on deploy — no chart-side UI edits required.

## Changes

### \`dbt_orders.yml\` (extends existing pre-aggs)
- \`orders_partner_daily\`: adds \`average_of_basket_total\` + \`avg_profit\` to metrics
- \`orders_partner_geo_daily\`: adds \`partner_commission\` as a dimension (1:1 with \`partner_name\`, so no cardinality explosion) + the same two new metrics

### \`dbt_baskets.yml\` (extends existing pre-aggs)
- \`baskets_product_partner\` + \`baskets_product_partner_recent_daily\`: adds \`sum_of_basket_total\` to metrics

### \`dbt_support_requests.yml\` (new pre-agg)
- \`support_requests_daily\`: time_dim \`request_date\` day, dims \`[reason]\`, metric \`[average_of_feedback_rating]\`

## Charts that auto-hit after deploy

| Dashboard | Chart | New pre-agg coverage |
|---|---|---|
| 🧭 KPI dashboard | What is our total revenue this month? | \`orders_partner_geo_daily\` + \`partner_commission\` |
| 🧭 KPI dashboard | Top 5 products by revenue | \`baskets_product_partner\` + \`sum_of_basket_total\` |
| 🧭 KPI dashboard | Weekly avg feedback rating | new \`support_requests_daily\` |
| Sales dashboard | What is our total revenue this month? | \`orders_partner_geo_daily\` + \`partner_commission\` |
| A dashboard with tabs | What is our total revenue this month? | same |
| Hamzahs' new fantastic dashboard | Monthly basket total | baskets + \`sum_of_basket_total\` |
| KPI Dashboard | KPI - Avg Order Value | orders + \`average_of_basket_total\` |
| Sales KPI Dashboard | Average Order Value Trend | orders + \`average_of_basket_total\` |
| Pre aggregates sneak peek | Avg order value by partner | orders + \`average_of_basket_total\` |
| Sales Dashboard (Test) | Avg Order Value vs Profit Margin | orders + \`average_of_basket_total\` (profit_margin is type: number custom SQL — still blocked on that metric alone) |
| Demo DashCache | 2 "Without DashCache" avg_profit charts | orders + \`avg_profit\` |
| pre-aggregations check | same 2 charts | same |
| Demo styling | Weekly avg feedback rating | new \`support_requests_daily\` |

## Not shipped (documented in audit)

- Charts using count_distinct metrics (\`count_distinct_order_id\`, \`count_distinct_user_id\`, \`count_distinct_request_id\`) — same proxy pattern from the lightdash-analytics audit applies but requires UI metric swaps. Candidate for a v1 stacked PR.
- Charts using parameterised dimensions (\`order_date_period\`, \`order_date_custom_period\`) — blocked by the same parameter issue as Support Metrics tab 2 in the analytics project.
- Charts using \`profit_margin\` (type: number custom SQL) or \`median_profit\` (type: median) — not pre-aggregatable.

## Test plan
- [ ] \`lightdash deploy\` passes
- [ ] The 5 pre-aggregates (2 on orders, 2 on baskets, 1 new on support_requests) materialise
- [ ] Spot-check the dashboards above — charts should show as pre-agg hits
- [ ] Values match previous non-pre-aggregated results

🤖 Generated with [Claude Code](https://claude.com/claude-code)