### PR TITLE
feat(pre-aggregates): dbt_users pre-agg to unlock 🧭 KPI dashboard

### DIFF
--- a/dbt-bigquery/models/dbt_orders.yml
+++ b/dbt-bigquery/models/dbt_orders.yml
@@ -13,6 +13,7 @@ models:
             - sum_of_profit
             - average_of_basket_total
             - avg_profit
+            - count_of_order_id_agg
           time_dimension: order_date
           granularity: DAY
         - name: orders_partner_geo_daily
@@ -26,6 +27,7 @@ models:
             - sum_of_profit
             - average_of_basket_total
             - avg_profit
+            - count_of_order_id_agg
           time_dimension: order_date
           granularity: DAY
       spotlight:
@@ -72,6 +74,16 @@ models:
                 categories:
                   - verified
                   - sales
+            count_of_order_id_agg:
+              type: count
+              label: 'Order Volume (aggregatable)'
+              description: >-
+                Re-aggregatable proxy for count_distinct_order_id. Used
+                internally for pre-aggregation. dbt_orders has one row per
+                order_id, so count ≡ count_distinct.
+              hidden: true
+              spotlight:
+                visibility: hide
           dimension:
             type: string
       - name: order_date

--- a/dbt-bigquery/models/dbt_support_requests.yml
+++ b/dbt-bigquery/models/dbt_support_requests.yml
@@ -10,6 +10,7 @@ models:
             - reason
           metrics:
             - average_of_feedback_rating
+            - count_of_request_id_agg
           time_dimension: request_date
           granularity: DAY
       joins:
@@ -29,6 +30,16 @@ models:
                 categories:
                   - verified
                   - operations
+            count_of_request_id_agg:
+              type: count
+              label: Support Tickets (aggregatable)
+              description: >-
+                Re-aggregatable proxy for count_distinct_request_id. Used
+                internally for pre-aggregation. dbt_support_requests has one
+                row per request_id, so count ≡ count_distinct.
+              hidden: true
+              spotlight:
+                visibility: hide
           dimension:
             type: string
       - name: order_id

--- a/dbt-bigquery/models/dbt_users.yml
+++ b/dbt-bigquery/models/dbt_users.yml
@@ -3,6 +3,14 @@ models:
     description: 'This table contains information on all of our users and customers'
     meta:
       label: Users
+      pre_aggregates:
+        - name: users_daily_by_browser
+          dimensions:
+            - browser
+          metrics:
+            - count_of_user_id_agg
+          time_dimension: created_date
+          granularity: DAY
       joins:
         - join: dbt_orders
           sql_on: ${dbt_users.user_id} = ${dbt_orders.user_id}
@@ -73,5 +81,15 @@ models:
                 categories:
                   - verified
                   - marketing
+            count_of_user_id_agg:
+              type: count
+              label: Total Customers (aggregatable)
+              description: >-
+                Re-aggregatable proxy for count_distinct_of_user_id. Used
+                internally for pre-aggregation. dbt_users has one row per
+                user_id, so count ≡ count_distinct.
+              hidden: true
+              spotlight:
+                visibility: hide
           dimension:
             type: string


### PR DESCRIPTION
## v1 — KPI dashboard blockers

Stacks on v0 (#80). This PR adds the re-aggregatable `_agg` proxy metrics and a new `dbt_users` pre-aggregate. Unlike v0, these changes need **chart-side metric swaps in the UI** to take effect.

## Audit context

Looking at 🧭 KPI dashboard charts-as-code + the dashboard filters:

**Dashboard filters applied to most order/basket tiles:**
- `browser = [chrome, safari, edge, firefox]`
- `order_date_day inThePast 26 weeks`
- `partner_name` (disabled)

The existing `orders_partner_geo_daily` already covers `browser` as a dim, so filter propagation works — **the real blocker for 9 of the 11 "miss" charts is count_distinct metrics**, which can't live in a pre-aggregate. Proxy pattern solves it.

## Changes

| Model | Addition |
|---|---|
| `dbt_orders.yml` | `count_of_order_id_agg` (hidden count proxy on `order_id`); added to both `orders_partner_daily` and `orders_partner_geo_daily` metrics |
| `dbt_support_requests.yml` | `count_of_request_id_agg` (hidden count proxy on `request_id`); added to `support_requests_daily` metrics |
| `dbt_users.yml` | `count_of_user_id_agg` (hidden count proxy on `user_id`); new pre-agg `users_daily_by_browser` (time_dim `created_date` DAY, dims `[browser]`, metric `[count_of_user_id_agg]`) |

All proxies are safe — each base table has one row per its primary key, so `count(pk) ≡ count_distinct(pk)`.

## UI follow-up — swap metrics on these charts (after deploy)

| Chart | Swap |
|---|---|
| How many orders have we fulfilled? | `count_distinct_order_id` → `count_of_order_id_agg` |
| Orders per Partner | same |
| What are the sales stats per partner, per month? | same |
| How is the average order amount ($) trending each week? | same (keep `sum_of_basket_total` and `average_of_basket_total`) |
| What support request reasons are the most common by percentage? | `count_distinct_request_id` → `count_of_request_id_agg` |
| How many users were created each month? | `count_distinct_of_user_id` → `count_of_user_id_agg` |
| Users by browser | same |

## Still structurally blocked (not fixable by pre-aggs alone)

- **Average order count per user per month** — chart-level table calc `average_orders_per_user`. Would unlock if the ratio moved into dbt as a `type: number` metric.
- **Partner profit performance** — chart-level table calc `profit_margin_1`. Same pattern.
- **What is our total profit?** — chart-level filter `basket_total > 1`. basket_total is a high-cardinality numeric dim; can't reasonably go in pre-agg dims. Remove the filter from the chart (likely redundant) or accept the miss.
- **Top 5 products by revenue** — audit says "Filter dimension not in pre-aggregate" but the chart has no explicit filter; likely a dashboard-filter tile-target resolution gap on `dbt_baskets` rather than something I can fix with a dim add.

## Test plan
- [ ] `lightdash deploy` passes
- [ ] New pre-agg `users_daily_by_browser` materialises
- [ ] Existing pre-aggs refresh with new metric columns
- [ ] Work through the UI follow-up table above
- [ ] Re-run the pre-agg audit — 7 "miss" charts should flip to hits, plus the 2 "without pre-agg" user charts

🤖 Generated with [Claude Code](https://claude.com/claude-code)