### PR TITLE
v2: add count_distinct metrics directly to pre-aggregates (test)

### DIFF
--- a/dbt-bigquery/models/dbt_orders.yml
+++ b/dbt-bigquery/models/dbt_orders.yml
@@ -14,6 +14,7 @@ models:
             - average_of_basket_total
             - avg_profit
             - count_of_order_id_agg
+            - count_distinct_order_id
           time_dimension: order_date
           granularity: DAY
         - name: orders_partner_geo_daily
@@ -28,6 +29,7 @@ models:
             - average_of_basket_total
             - avg_profit
             - count_of_order_id_agg
+            - count_distinct_order_id
           time_dimension: order_date
           granularity: DAY
       spotlight:

--- a/dbt-bigquery/models/dbt_support_requests.yml
+++ b/dbt-bigquery/models/dbt_support_requests.yml
@@ -11,6 +11,7 @@ models:
           metrics:
             - average_of_feedback_rating
             - count_of_request_id_agg
+            - count_distinct_request_id
           time_dimension: request_date
           granularity: DAY
       joins:

--- a/dbt-bigquery/models/dbt_users.yml
+++ b/dbt-bigquery/models/dbt_users.yml
@@ -9,6 +9,7 @@ models:
             - browser
           metrics:
             - count_of_user_id_agg
+            - count_distinct_of_user_id
           time_dimension: created_date
           granularity: DAY
       joins:


### PR DESCRIPTION
## Probing a different approach

Previous v1 (#81) shipped \`_agg\` count proxies. Those require UI metric swaps on the charts to take effect — and after merging, the audit still shows 5 "metric_not_in_pre_aggregate" misses because the chart tiles haven't been swapped to the proxies.

**v2 hypothesis:** list the native \`count_distinct_*\` metrics directly in the pre-agg's metrics array alongside the existing \`_agg\` proxies. If Lightdash tolerates count_distinct in pre-aggs at exact-grain matches (which the matcher's "query grouping must match or be a superset" rule would allow when the distinct key is the base table PK), charts would auto-hit **without** any UI swap.

## What this tests

If Lightdash's docs line ("pre-aggregates cannot serve count_distinct") means they're rejected at compile, this PR will fail CI and we'll revert. If they're tolerated at exact-grain matches, we skip the UI swap step entirely for 5 tiles.

## Changes

- \`dbt_orders\`: add \`count_distinct_order_id\` to both \`orders_partner_daily\` and \`orders_partner_geo_daily\` metrics
- \`dbt_support_requests\`: add \`count_distinct_request_id\` to \`support_requests_daily\` metrics
- \`dbt_users\`: add \`count_distinct_of_user_id\` to \`users_daily_by_browser\` metrics

## If compile passes

Re-run the pre-agg audit — should see the 5 "metric_not_in_pre_aggregate" misses flip to hits on any chart whose grouping matches or rolls up from the pre-agg grain. The _agg proxies stay in place (don't remove — they're already harmless and get used for queries at coarser/different groupings).

## If compile fails

Revert and keep the proxy + UI swap approach from v1.

## Not covered

- Filter on \`dbt_baskets_order_date_day\` (Top 5 products) — separate issue, likely tile-target resolution on dbt_baskets
- Filter on \`dbt_orders_basket_total\` (total profit) — continuous numeric dim can't reasonably be pre-aggregated
- Table calc blocked charts (Average order count per user per month, Partner profit performance) — structural, needs dbt-side refactor of the ratio

🤖 Generated with [Claude Code](https://claude.com/claude-code)