### PR TITLE
fix(baskets): drop inThePast filter to isolate Top 5 products miss

### DIFF
--- a/dbt-bigquery/models/dbt_baskets.yml
+++ b/dbt-bigquery/models/dbt_baskets.yml
@@ -25,8 +25,6 @@ models:
             - sum_of_item_profit
             - count_of_product_name
             - sum_of_basket_total
-          filters:
-            - order_date: inThePast 52 weeks
           time_dimension: order_date
           granularity: DAY
       groups:


### PR DESCRIPTION
## Experiment to isolate the bug

"Top 5 products by revenue" is flagged \`Filter dimension not in pre-aggregate\` despite the existing \`baskets_product_partner_recent_daily\` having every dim and metric the query needs.

Source code review in \`lightdash/lightdash\` showed:
- Duplicate \`order_date\` in \`dimensions\` + \`time_dimension\` is **handled correctly** (there's an explicit test case for it in \`matcher.test.ts\`).
- The \`filters: - order_date: inThePast 52 weeks\` syntax **does parse** via a PEG grammar in \`filterGrammar.ts\`.

So theoretically both should work. Since the audit still flags a miss, one of these two hypotheses is likely:

1. **BigQuery is silently failing to materialise the pre-agg** with the \`inThePast 52 weeks\` clause. If the pre-agg doesn't exist at query time, any match attempt looks like a "dim not in pre-aggregate" miss.
2. Some other matcher edge case I couldn't trace.

This PR **only drops the \`filters\` block** — keeping \`order_date\` in dims for now. If "Top 5 products" flips to a hit after deploy, filter syntax was the cause and we can re-add the 52-week limit in a different form later. If not, next experiment is to drop \`order_date\` from dims.

## Test plan
- [ ] \`lightdash deploy\` passes
- [ ] \`baskets_product_partner_recent_daily\` re-materialises (no filter means full history now)
- [ ] Pre-agg audit on 🧭 KPI dashboard — "Top 5 products by revenue" should show as a hit

🤖 Generated with [Claude Code](https://claude.com/claude-code)