### PR TITLE
fix(orders): add basket_total dim to pre-aggs to unblock Total Profit chart

### DIFF
--- a/dbt-bigquery/models/dbt_orders.yml
+++ b/dbt-bigquery/models/dbt_orders.yml
@@ -8,6 +8,7 @@ models:
         - name: orders_partner_daily
           dimensions:
             - partner_name
+            - basket_total
           metrics:
             - sum_of_basket_total
             - sum_of_profit
@@ -22,6 +23,7 @@ models:
             - partner_commission
             - shipping_country
             - browser
+            - basket_total
           metrics:
             - sum_of_basket_total
             - sum_of_profit


### PR DESCRIPTION
## Root cause

"What is our total profit?" on 🧭 KPI dashboard has its own chart-level filter `dbt_orders_basket_total > 1`. For pre-agg matching, every dimension used in a filter must be in the pre-aggregate's `dimensions` list. `basket_total` wasn't there → `"Filter dimension not in pre-aggregate"`.

To answer the question directly: `browser` IS already in `orders_partner_geo_daily` — it's not the blocker.

## The fix

Just add `basket_total` to both orders pre-aggs' dimensions. It's already a declared `type: number` dimension on the model, so this is a one-line add per pre-agg.

```yaml
pre_aggregates:
  - name: orders_partner_daily
    dimensions:
      - partner_name
      - basket_total    # <-- added
    ...
  - name: orders_partner_geo_daily
    dimensions:
      - partner_name
      - partner_commission
      - shipping_country
      - browser
      - basket_total    # <-- added
    ...
```

## Heads up on cardinality

`basket_total` is continuous numeric — each distinct dollar value becomes its own bucket in the materialized pre-agg. On the demo dataset this is fine; on production-scale data you'd want a bucketed/boolean flag instead. Leaving a note here in case it becomes relevant later.

## No chart edits needed

After `lightdash deploy` / dbt refresh, the chart's existing `basket_total > 1` filter matches the new dim directly. "What is our total profit?" should flip to a hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)