### PR TITLE
feat(dbt): promote _agg proxies to visible + add commission metric

### DIFF
--- a/dbt-bigquery/models/dbt_orders.yml
+++ b/dbt-bigquery/models/dbt_orders.yml
@@ -9,12 +9,14 @@ models:
           dimensions:
             - partner_name
             - basket_total
+            - referrer
           metrics:
             - sum_of_basket_total
             - sum_of_profit
             - average_of_basket_total
             - avg_profit
-            - count_of_order_id_agg
+            - count_of_order_id
+            - sum_of_partner_commission
           time_dimension: order_date
           granularity: DAY
         - name: orders_partner_geo_daily
@@ -24,12 +26,14 @@ models:
             - shipping_country
             - browser
             - basket_total
+            - referrer
           metrics:
             - sum_of_basket_total
             - sum_of_profit
             - average_of_basket_total
             - avg_profit
-            - count_of_order_id_agg
+            - count_of_order_id
+            - sum_of_partner_commission
           time_dimension: order_date
           granularity: DAY
       spotlight:
@@ -76,16 +80,19 @@ models:
                 categories:
                   - verified
                   - sales
-            count_of_order_id_agg:
+            count_of_order_id:
               type: count
-              label: 'Order Volume (aggregatable)'
+              label: 'Order Volume'
               description: >-
-                Re-aggregatable proxy for count_distinct_order_id. Used
-                internally for pre-aggregation. dbt_orders has one row per
-                order_id, so count ≡ count_distinct.
-              hidden: true
+                Count of orders. dbt_orders is one row per order_id, so this
+                is equivalent to count_distinct_order_id — but it's
+                re-aggregatable, so it can live in pre-aggregates and be
+                used in time-window roll-ups without query-time work.
               spotlight:
-                visibility: hide
+                visibility: show
+                categories:
+                  - verified
+                  - sales
           dimension:
             type: string
       - name: order_date
@@ -255,6 +262,16 @@ models:
         meta:
           dimension:
             type: number
+          metrics:
+            sum_of_partner_commission:
+              type: sum
+              label: 'Sum of Partner commission'
+              description: 'Total commission paid to partners across orders.'
+              format: '[$$]#,##0'
+              spotlight:
+                visibility: show
+                categories:
+                  - finance
       - name: currency
         description: 'Three letter international currency code for the currency the
           order was paid with.'

--- a/dbt-bigquery/models/dbt_support_requests.yml
+++ b/dbt-bigquery/models/dbt_support_requests.yml
@@ -10,7 +10,7 @@ models:
             - reason
           metrics:
             - average_of_feedback_rating
-            - count_of_request_id_agg
+            - count_of_request_id
           time_dimension: request_date
           granularity: DAY
       joins:
@@ -30,16 +30,19 @@ models:
                 categories:
                   - verified
                   - operations
-            count_of_request_id_agg:
+            count_of_request_id:
               type: count
-              label: Support Tickets (aggregatable)
+              label: Support Tickets
               description: >-
-                Re-aggregatable proxy for count_distinct_request_id. Used
-                internally for pre-aggregation. dbt_support_requests has one
-                row per request_id, so count ≡ count_distinct.
-              hidden: true
+                Count of support tickets. dbt_support_requests is one row per
+                request_id, so this is equivalent to count_distinct_request_id
+                — but it's re-aggregatable, so it can live in pre-aggregates
+                and be used in time-window roll-ups without query-time work.
               spotlight:
-                visibility: hide
+                visibility: show
+                categories:
+                  - verified
+                  - operations
           dimension:
             type: string
       - name: order_id

--- a/dbt-bigquery/models/dbt_users.yml
+++ b/dbt-bigquery/models/dbt_users.yml
@@ -8,7 +8,7 @@ models:
           dimensions:
             - browser
           metrics:
-            - count_of_user_id_agg
+            - count_of_user_id
           time_dimension: created_date
           granularity: DAY
       joins:
@@ -81,15 +81,18 @@ models:
                 categories:
                   - verified
                   - marketing
-            count_of_user_id_agg:
+            count_of_user_id:
               type: count
-              label: Total Customers (aggregatable)
+              label: Total Customers
               description: >-
-                Re-aggregatable proxy for count_distinct_of_user_id. Used
-                internally for pre-aggregation. dbt_users has one row per
-                user_id, so count ≡ count_distinct.
-              hidden: true
+                Count of customers. dbt_users is one row per user_id, so this
+                is equivalent to count_distinct_of_user_id — but it's
+                re-aggregatable, so it can live in pre-aggregates and be
+                used in time-window roll-ups without query-time work.
               spotlight:
-                visibility: hide
+                visibility: show
+                categories:
+                  - verified
+                  - marketing
           dimension:
             type: string


### PR DESCRIPTION
## What this does

Three housekeeping + one unblock in one PR.

### 1. Promote hidden \`_agg\` proxies → visible first-class count metrics

Each base table is one-row-per-PK, so \`type: count\` is equivalent to \`count_distinct\` but re-aggregatable (lives in pre-aggs). The existing proxies were hidden helpers; unhiding and renaming makes them the natural choice in the UI.

| Model | Before | After |
|---|---|---|
| \`dbt_orders\` | \`count_of_order_id_agg\` (hidden) | \`count_of_order_id\` (visible) |
| \`dbt_support_requests\` | \`count_of_request_id_agg\` (hidden) | \`count_of_request_id\` (visible) |
| \`dbt_users\` | \`count_of_user_id_agg\` (hidden) | \`count_of_user_id\` (visible) |

The defensive \`count_distinct_*\` metrics are left in place for backward compatibility, but the \`count_of_*\` versions are the ones the UI will surface naturally now.

### 2. New native metric for commission-by-referrer

\`comission by referrer\` chart currently uses a chart-level custom (additional) metric \`SUM(partner_commission)\`. Promoted to a proper native metric on the model:

\`\`\`yaml
sum_of_partner_commission:
  type: sum
  label: 'Sum of Partner commission'
\`\`\`

### 3. Added \`referrer\` as a dim on both orders pre-aggs

Required so queries grouping by \`referrer\` (like the commission chart) can match.

## Follow-up after merge + \`lightdash deploy\`

- **Monthly Order Value**: swap \`count_distinct_order_id\` → \`count_of_order_id\` (upload).
- **comission by referrer**: remove chart-level additional metric, use \`sum_of_partner_commission\` directly (upload).
- **Previously-swapped 7 charts** (from #81's UI swaps): currently reference \`*_agg\` names — need one more swap to the new un-suffixed names. I'll do all of these via download/upload once this is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)