### PR TITLE
feat: add Unique Customers metric and Support Tickets per Customer ratio to dbt_support_requests

### DIFF
--- a/dbt-bigquery/models/dbt_support_requests.yml
+++ b/dbt-bigquery/models/dbt_support_requests.yml
@@ -4,6 +4,20 @@ models:
       received'
     meta:
       label: Support requests
+      metrics:
+        support_tickets_per_customer:
+          type: number
+          label: Support Tickets per Customer
+          description: >-
+            Average number of support tickets submitted per customer, calculated
+            as total support tickets divided by unique customers.
+          sql: ${count_of_request_id} / NULLIF(${count_distinct_user_id}, 0)
+          round: 2
+          spotlight:
+            visibility: show
+            categories:
+              - verified
+              - operations
       pre_aggregates:
         - name: support_requests_daily
           dimensions:
@@ -11,6 +25,7 @@ models:
           metrics:
             - average_of_feedback_rating
             - count_of_request_id
+            - count_distinct_user_id
           time_dimension: request_date
           granularity: DAY
       joins:
@@ -129,6 +144,16 @@ models:
       - name: user_id
         description: ""
         meta:
+          metrics:
+            count_distinct_user_id:
+              type: count_distinct
+              label: Unique Customers
+              description: Number of unique customers who submitted support tickets.
+              spotlight:
+                visibility: hide
+                categories:
+                  - verified
+                  - operations
           dimension:
             type: string
       - name: email


### PR DESCRIPTION
## Changes

- Added `count_distinct_user_id` metric (type: count_distinct) on the `user_id` column, labelled "Unique Customers", with spotlight visibility hidden and categories `[verified, operations]`.
- Added model-level metric `support_tickets_per_customer` (type: number) computing `${count_of_request_id} / NULLIF(${count_distinct_user_id}, 0)`, rounded to 2 decimal places, labelled "Support Tickets per Customer", with spotlight visibility shown and categories `[verified, operations]`.
- Added `count_distinct_user_id` to the `support_requests_daily` pre-aggregate metrics list so unique customer counts are available in time-windowed roll-ups.

## Validation

- `lightdash compile` passes with exit 0, all 5 explores compiled successfully.