### PR TITLE
Remove support_tickets_per_customer model-level metric from dbt_support_requests

### DIFF
--- a/dbt-bigquery/models/dbt_support_requests.yml
+++ b/dbt-bigquery/models/dbt_support_requests.yml
@@ -4,20 +4,6 @@ models:
       received'
     meta:
       label: Support requests
-      metrics:
-        support_tickets_per_customer:
-          type: number
-          label: Support Tickets per Customer
-          description: >-
-            Average number of support tickets submitted per customer, calculated
-            as total support tickets divided by unique customers.
-          sql: ${count_of_request_id} / NULLIF(${count_distinct_user_id}, 0)
-          round: 2
-          spotlight:
-            visibility: show
-            categories:
-              - verified
-              - operations
       pre_aggregates:
         - name: support_requests_daily
           dimensions:


### PR DESCRIPTION
## Summary

- Deleted the `support_tickets_per_customer` metric block (including its `type`, `label`, `description`, `sql`, `round`, and `spotlight` fields) from `models[].meta.metrics` in `dbt-bigquery/models/dbt_support_requests.yml`.
- The `metrics:` key under `meta` was removed entirely as it was the sole entry.
- No other metrics, dimensions, joins, pre-aggregates, or model SQL were modified.

## Test plan

- [ ] Confirm `support_tickets_per_customer` no longer appears in the Lightdash explore for Support Requests.
- [ ] Verify all other metrics and dimensions on the model remain intact.