### PR TITLE
Add support_tickets_per_customer model-level metric to dbt_support_requests

### DIFF
--- a/dbt-bigquery/models/dbt_support_requests.yml
+++ b/dbt-bigquery/models/dbt_support_requests.yml
@@ -17,6 +17,17 @@ models:
       joins:
         - join: dbt_orders
           sql_on: ${dbt_orders.order_id} = ${dbt_support_requests.order_id}
+      metrics:
+        support_tickets_per_customer:
+          type: number
+          label: Support Tickets per Customer
+          description: Average number of support tickets submitted per unique customer.
+          sql: "ROUND(${count_of_request_id} / NULLIF(${count_distinct_user_id}, 0), 2)"
+          format: '0.00'
+          spotlight:
+            visibility: show
+            categories:
+              - operations
     columns:
       - name: request_id
         description: 'Unique ID of the request.'


### PR DESCRIPTION
## Summary

- Added a new `number` type model-level metric `support_tickets_per_customer` under `models[].meta.metrics` in `dbt_support_requests.yml`
- The metric computes the average support tickets per unique customer using `ROUND(${count_of_request_id} / NULLIF(${count_distinct_user_id}, 0), 2)`
- Formatted as `0.00`, visible in spotlight under the `operations` category

## Test plan

- [x] `lightdash compile` passes with exit 0
- [ ] Verify metric appears in the Lightdash UI under the Support Requests explore with the correct label and formatting