### PR TITLE
Add support_tickets_per_customer metric to dbt_support_requests

### DIFF
--- a/dbt-bigquery/models/dbt_support_requests.yml
+++ b/dbt-bigquery/models/dbt_support_requests.yml
@@ -140,6 +140,17 @@ models:
                 categories:
                   - verified
                   - operations
+            support_tickets_per_customer:
+              type: number
+              label: Support Tickets per Customer
+              description: >-
+                Average number of support tickets submitted per unique customer. Calculated as support tickets divided by unique customers.
+              sql: "${count_of_request_id} / nullif(${count_distinct_user_id}, 0)"
+              spotlight:
+                visibility: show
+                categories:
+                  - verified
+                  - operations
           dimension:
             type: string
       - name: email


### PR DESCRIPTION
## Changes

- Added a new `support_tickets_per_customer` metric under the `user_id` column in `models/dbt_support_requests.yml`
- **Type:** `number`
- **Label:** Support Tickets per Customer
- **Description:** Average number of support tickets submitted per unique customer. Calculated as support tickets divided by unique customers.
- **SQL:** `${count_of_request_id} / nullif(${count_distinct_user_id}, 0)` — uses `NULLIF` to avoid division-by-zero when there are no customers
- **Spotlight:** visibility `show`, categories `verified` and `operations`

The metric follows the same YAML style and indentation as existing metrics in the file.