### PR TITLE
Add support_tickets_per_customer metric to dbt_support_requests

### DIFF
--- a/dbt-bigquery/models/dbt_support_requests.yml
+++ b/dbt-bigquery/models/dbt_support_requests.yml
@@ -44,6 +44,16 @@ models:
                 categories:
                   - verified
                   - operations
+            support_tickets_per_customer:
+              type: number
+              sql: "ROUND(1.0 * COUNT(${TABLE}.request_id) / NULLIF(COUNT(DISTINCT ${TABLE}.user_id), 0), 2)"
+              label: "Support Tickets per Customer"
+              description: "Average number of support tickets submitted per unique customer. Calculated as total support tickets divided by unique customers with tickets."
+              spotlight:
+                visibility: show
+                categories:
+                  - verified
+                  - operations
           dimension:
             type: string
       - name: order_id


### PR DESCRIPTION
## Summary

- Added a new `support_tickets_per_customer` derived `number` metric to the `request_id` column in `models/dbt_support_requests.yml`
- Metric uses `ROUND(1.0 * COUNT(request_id) / NULLIF(COUNT(DISTINCT user_id), 0), 2)` to compute average tickets per unique customer
- Configured with `spotlight.visibility: show` and categories `[verified, operations]`, consistent with the existing support ticket metrics

## Test plan

- [ ] Lightdash compile passes (confirmed: exit 0, 5 explores, 0 errors)
- [ ] Metric appears in the Lightdash UI under the Support Requests explore
- [ ] Metric value looks correct: total tickets divided by unique customers, rounded to 2 decimal places