### PR TITLE
Consolidate order-count metrics: remove count_distinct_order_id from dbt_orders

### DIFF
--- a/dbt-bigquery/models/dbt_orders.yml
+++ b/dbt-bigquery/models/dbt_orders.yml
@@ -54,15 +54,6 @@ models:
         description: 'Unique Order ID for the order.'
         meta:
           metrics:
-            count_distinct_order_id:
-              type: count_distinct
-              label: 'Order Volume'
-              description: 'Total number of orders placed by customers. Watch your garden grow!'
-              spotlight:
-                visibility: show
-                categories:
-                  - verified
-                  - sales
             count_of_order_id:
               type: count
               label: 'Order Volume'

--- a/dbt-bigquery/models/dbt_users.yml
+++ b/dbt-bigquery/models/dbt_users.yml
@@ -14,7 +14,7 @@ models:
       joins:
         - join: dbt_orders
           sql_on: ${dbt_users.user_id} = ${dbt_orders.user_id}
-          fields: [ count_distinct_order_id ]
+          fields: [ count_of_order_id ]
       metrics:
         diff_emails_to_users:
           type: number


### PR DESCRIPTION
## Changes

- `dbt_orders.yml`: Removed the duplicate `count_distinct_order_id` metric from `order_id.meta.metrics`. `count_of_order_id` (type: count) is now the single canonical "Order Volume" metric for the Orders explore. Its description already explains that `dbt_orders` is one row per `order_id`, making `count` equivalent to `count_distinct` while remaining re-aggregatable for pre-aggregates and time-window roll-ups.
- `dbt_users.yml`: Updated the `dbt_orders` join's `fields` list from `count_distinct_order_id` to `count_of_order_id` so the Users explore continues to expose the correct joined metric.
- `dbt_orders_no_preagg.yml`: No changes — the non-pre-aggregated explore retains its own `count_distinct_order_id` metric independently.

## Test plan
- [ ] Lightdash compile passes (confirmed: exit 0, 5/5 explores SUCCESS)
- [ ] Orders explore exposes a single "Order Volume" metric (`count_of_order_id`)
- [ ] Users explore joined metrics field resolves to `count_of_order_id`
- [ ] Orders No-Preagg explore still shows its `count_distinct_order_id` metric unchanged