### PR TITLE
docs(skills): refresh workflows reference to node24-runtime actions

### DIFF
--- a/.claude/skills/developing-in-lightdash/resources/workflows-reference.md
+++ b/.claude/skills/developing-in-lightdash/resources/workflows-reference.md
@@ -63,18 +63,18 @@ jobs:
       LIGHTDASH_PROJECT: ${{ secrets.PROJECT_UUID }}
       CI: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Install Lightdash CLI
         run: npm install -g @lightdash/cli
 
       - name: Setup Python (for dbt)
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -173,12 +173,12 @@ jobs:
       LIGHTDASH_URL: https://app.lightdash.cloud
       CI: "true"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Install Lightdash CLI
         run: npm install -g @lightdash/cli
@@ -190,7 +190,7 @@ jobs:
         run: lightdash start-preview --name "pr-${{ github.event.number }}"
 
       - name: Comment on PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             github.rest.issues.createComment({
@@ -332,7 +332,7 @@ jobs:
       LIGHTDASH_URL: https://app.lightdash.cloud
       CI: "true"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install tools
         run: |

--- a/.cursor/skills/developing-in-lightdash/resources/workflows-reference.md
+++ b/.cursor/skills/developing-in-lightdash/resources/workflows-reference.md
@@ -63,18 +63,18 @@ jobs:
       LIGHTDASH_PROJECT: ${{ secrets.PROJECT_UUID }}
       CI: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Install Lightdash CLI
         run: npm install -g @lightdash/cli
 
       - name: Setup Python (for dbt)
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -173,12 +173,12 @@ jobs:
       LIGHTDASH_URL: https://app.lightdash.cloud
       CI: "true"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Install Lightdash CLI
         run: npm install -g @lightdash/cli
@@ -190,7 +190,7 @@ jobs:
         run: lightdash start-preview --name "pr-${{ github.event.number }}"
 
       - name: Comment on PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             github.rest.issues.createComment({
@@ -332,7 +332,7 @@ jobs:
       LIGHTDASH_URL: https://app.lightdash.cloud
       CI: "true"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install tools
         run: |


### PR DESCRIPTION
## What

Refreshes the `developing-in-lightdash` skill snapshot in this repo to match the master in `lightdash/lightdash`.

The skill is distributed by `lightdash install-skills`, which downloads a **snapshot** — there is no live sync, so copies drift until someone re-installs. This copy predates the master being fixed and still recommends actions whose declared runtime is node20, plus `node-version: '20'`.

| | was | now |
|---|---|---|
| `actions/checkout` | v4 | v6 |
| `actions/setup-node` | v4 | v6 |
| `actions/setup-python` | v5 | v6 |
| `actions/github-script` | v7 | v9 |
| `node-version` | '20' | '24' |

## Verification

The file is now byte-identical to `skills/developing-in-lightdash/resources/workflows-reference.md` on `lightdash/lightdash@main` (fixed in lightdash#27390). The only difference before this change was those nine lines — no local customisation was overwritten, which was checked by diffing against master first.

Documentation only. Nothing in this repo executes it.

Linear: PROD-10128